### PR TITLE
Allow to use custom text for close button

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Text that will appear on the button that moves the tour backwards. Defaults to `
 #### `doneButtonText`
 Text that will appear on the button that finishes the tour. Defaults to `Done`
 
+#### `closeButtonText`
+Text that will appear on the button that closes the tour. Defaults to `Close`
+
 #### `hideButtons`
 Boolean to disable the showing of next/back/done buttons. Set this to true if you want to insert your own buttons in the body.
 

--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,7 @@ export default class ReactUserTour extends Component {
 					style={xStyle}
 					onClick={this.props.onCancel}
 					onTouchTap={this.props.onCancel}>
-						Close
+						{this.props.closeButtonText}
 				</span> : ""
 		);
 
@@ -208,6 +208,7 @@ ReactUserTour.defaultProps = {
 	nextButtonText: "Next",
 	backButtonText: "Back",
 	doneButtonText: "Done",
+	closeButtonText: "Close",
 	buttonContainerStyle: {
 		position: "absolute",
 		bottom: 10,


### PR DESCRIPTION
This should increase flexibility as "Skip" or some other keyword might be more appropriate than the default "Close" in some cases.